### PR TITLE
(Youtube Downloader) Allow `-` in production code

### DIFF
--- a/root/scripts/Youtube-Series-Downloader.bash
+++ b/root/scripts/Youtube-Series-Downloader.bash
@@ -99,7 +99,7 @@ for id in $(echo $sonarrSeriesIds); do
         if [ -z $downloadUrl ]; then
             network="$(echo "$tvdbPageData" | grep -i "/companies/youtube")"
             if [ ! -z "$network" ]; then 
-                downloadUrl=$(echo "$tvdbPageData" | grep -iwns "production code" -A 2 | sed 's/\ //g' | cut -d "-" -f2 | tail -n1)
+                downloadUrl=$(echo "$tvdbPageData" | grep -iws "production code" -A 2 | sed 's/\ //g' | tail -n1)
                 if [ ! -z $downloadUrl ]; then
                     downloadUrl="https://www.youtube.com/watch?v=$downloadUrl"
                 fi


### PR DESCRIPTION
Allow production code to contain `-` characters

Example before:
```bash
 ➜  ~ curl -s "https://thetvdb.com/series/kurzgesagt-in-a-nutshell/episodes/8645109" | grep -iwns "production code" -A 2 | sed 's/\ //g' | cut -d "-" -f2 | tail -n1
1
```

After:
```bash
 ➜  ~ curl -s "https://thetvdb.com/series/kurzgesagt-in-a-nutshell/episodes/8645109" | grep -iws "production code" -A 2 | sed 's/\ //g' | tail -n1
1-NxodiGPCU
```