### PR TITLE
dockerfiles: ensuring bash scripts are executable

### DIFF
--- a/amd64.dockerfile
+++ b/amd64.dockerfile
@@ -62,6 +62,9 @@ WORKDIR /config
 # copy local files
 COPY root/ /
 
+# ensure scripts are executable
+RUN chmod +x /scripts/*.bash
+
 # ports and volumes
 EXPOSE 8989
 VOLUME /config

--- a/arm64v8.dockerfile
+++ b/arm64v8.dockerfile
@@ -70,6 +70,9 @@ WORKDIR /config
 # copy local files
 COPY root/ /
 
+# ensure scripts are executable
+RUN chmod +x /scripts/*.bash
+
 # ports and volumes
 EXPOSE 8989
 VOLUME /config


### PR DESCRIPTION
I don't know if it's just me, but I seem to be having trouble with the bash scripts not being executable in the container. Hopefully this should fix that issue.