### PR TITLE
Use case insensitive when looking for cookies

### DIFF
--- a/root/scripts/Extras.bash
+++ b/root/scripts/Extras.bash
@@ -76,7 +76,7 @@ fi
 DownloadExtras () {
 
     # Check for cookies file
-    if find /config -type f -name "cookies.txt" | read; then
+    if find /config -type f -iname "cookies.txt" | read; then
         cookiesFile="$(find /config -type f -iname "cookies.txt" | head -n1)"
         log "$itemTitle :: Cookies File Found!"
     else

--- a/root/scripts/Youtube-Series-Downloader.bash
+++ b/root/scripts/Youtube-Series-Downloader.bash
@@ -36,7 +36,7 @@ fi
 
 CookiesCheck () {
     # Check for cookies file
-    if find /config -type f -name "cookies.txt" | read; then
+    if find /config -type f -iname "cookies.txt" | read; then
         cookiesFile="$(find /config -type f -iname "cookies.txt" | head -n1)"
         log "Cookies File Found!"
     else


### PR DESCRIPTION
change `find` flag to use case insensitive search on `if` statement.

This will use the same flag that is used on the next line, so it will keep it consistent.