### PR TITLE
Add yt-dlp flag to prevent timed out error

### DIFF
--- a/root/scripts/Extras.bash
+++ b/root/scripts/Extras.bash
@@ -5,6 +5,7 @@ arrItemId=$sonarr_series_id
 tmdbApiKey="3b7751e3179f796565d88fdb2fcdf426"
 autoScan="false"
 updatePlex="false"
+ytdlpExtraOpts="--user-agent facebookexternalhit/1.1"
 
 if [ ! -z "$1" ]; then
     arrItemId="$1"
@@ -163,9 +164,9 @@ DownloadExtras () {
 
             log "$itemTitle :: $i of $tmdbVideosListDataIdsCount :: $tmdbExtraType :: $tmdbExtraTitle ($tmdbExtraKey) :: Downloading (yt-dlp :: $videoFormat)..."
             if [ ! -z "$cookiesFile" ]; then
-                yt-dlp -f "$videoFormat" --no-video-multistreams --cookies "$cookiesFile" -o "$finalPath/$tmdbExtraTitleClean" --write-sub --sub-lang $videoLanguages --embed-subs --merge-output-format mkv --no-mtime --geo-bypass "https://www.youtube.com/watch?v=$tmdbExtraKey" &>/dev/null
+                yt-dlp -f "$videoFormat" --no-video-multistreams --cookies "$cookiesFile" -o "$finalPath/$tmdbExtraTitleClean" --write-sub --sub-lang $videoLanguages --embed-subs --merge-output-format mkv --no-mtime --geo-bypass $ytdlpExtraOpts "https://www.youtube.com/watch?v=$tmdbExtraKey" &>/dev/null
             else
-                yt-dlp -f "$videoFormat" --no-video-multistreams -o "$finalPath/$tmdbExtraTitleClean" --write-sub --sub-lang $videoLanguages --embed-subs --merge-output-format mkv --no-mtime --geo-bypass "https://www.youtube.com/watch?v=$tmdbExtraKey" &>/dev/null
+                yt-dlp -f "$videoFormat" --no-video-multistreams -o "$finalPath/$tmdbExtraTitleClean" --write-sub --sub-lang $videoLanguages --embed-subs --merge-output-format mkv --no-mtime --geo-bypass $ytdlpExtraOpts "https://www.youtube.com/watch?v=$tmdbExtraKey" &>/dev/null
             fi
             if [ -f "$finalPath/$tmdbExtraTitleClean.mkv" ]; then
                 log "$itemTitle :: $i of $tmdbVideosListDataIdsCount :: $tmdbExtraType :: $tmdbExtraTitle ($tmdbExtraKey) :: Compete"

--- a/root/scripts/Youtube-Series-Downloader.bash
+++ b/root/scripts/Youtube-Series-Downloader.bash
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 scriptVersion="1.0.3"
+ytdlpExtraOpts="--user-agent facebookexternalhit/1.1"
 
 if [ -z "$arrUrl" ] || [ -z "$arrApiKey" ]; then
   arrUrlBase="$(cat /config/config.xml | xq | jq -r .Config.UrlBase)"
@@ -120,9 +121,9 @@ for id in $(echo $sonarrSeriesIds); do
         fileName="$seriesTitleDots.S${episodeSeasonNumber}E${episodeNumber}.WEB-DL-SonarrExtended"
         log "$loopCount/$sonarrSeriesTotal :: $currentLoopIteration/$seriesEpisodeTvdbIdsCount :: $seriesTitle :: S${episodeSeasonNumber}E${episodeNumber} :: Downloading via yt-dlp ($videoFormat)..."
         if [ ! -z "$cookiesFile" ]; then
-            yt-dlp -f "$videoFormat" --no-video-multistreams --cookies "$cookiesFile" -o "$downloadLocation/$fileName" --write-sub --sub-lang $videoLanguages --embed-subs --merge-output-format mkv --no-mtime --geo-bypass "$downloadUrl"
+            yt-dlp -f "$videoFormat" --no-video-multistreams --cookies "$cookiesFile" -o "$downloadLocation/$fileName" --write-sub --sub-lang $videoLanguages --embed-subs --merge-output-format mkv --no-mtime --geo-bypass $ytdlpExtraOpts "$downloadUrl"
         else
-            yt-dlp -f "$videoFormat" --no-video-multistreams -o "$downloadLocation/$fileName" --write-sub --sub-lang $videoLanguages --embed-subs --merge-output-format mkv --no-mtime --geo-bypass "$downloadUrl"
+            yt-dlp -f "$videoFormat" --no-video-multistreams -o "$downloadLocation/$fileName" --write-sub --sub-lang $videoLanguages --embed-subs --merge-output-format mkv --no-mtime --geo-bypass $ytdlpExtraOpts "$downloadUrl"
         fi
 
         if python3 /usr/local/sma/manual.py --config "/sma.ini" -i "$downloadLocation/$fileName.mkv" -nt; then


### PR DESCRIPTION
I'm having issues to download from `yt-dlp`.

Looking around I found this issue  https://github.com/yt-dlp/yt-dlp/issues/2396#issuecomment-1018262631 that introduces a workaround by adding a `--user-agent facebookexternalhit/1.1` flag to `yt-dlp`.

As it worked on my side and I don't see an issue using it by default, I'm sending this PR.

I've introduced this flag using a new variable at the beginning, making it easier to alter or remove it in future if required.